### PR TITLE
ci: make ./gradlew executable

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -28,6 +28,7 @@ jobs:
       with:
         java-version: '17'
         distribution: 'temurin'
+    - run: chmod +x ./gradlew
     - name: Build with Gradle
       uses: gradle/gradle-build-action@bd5760595778326ba7f1441bcf7e88b49de61a25 # v2.6.0
       with:


### PR DESCRIPTION
Added chmod command to the GitHub workflow so that ./gradlew was executable