### PR TITLE
Added a check to only register frog variants if RegistryAccess exists

### DIFF
--- a/src/main/java/lol/aabss/skuishy/elements/entities/Types.java
+++ b/src/main/java/lol/aabss/skuishy/elements/entities/Types.java
@@ -67,7 +67,8 @@ public class Types {
         }
 
         if (Skript.classExists("org.bukkit.entity.Frog") && Classes.getExactClassInfo(Frog.Variant.class) == null) {
-            Classes.registerClass(RegistryClassInfo.create(RegistryAccess.registryAccess().getRegistry(RegistryKey.FROG_VARIANT),
+            if (Skript.classExists("io.papermc.paper.registry.RegistryAccess") && Skript.classExists("io.papermc.paper.registry.RegistryKey"))
+                Classes.registerClass(RegistryClassInfo.create(RegistryAccess.registryAccess().getRegistry(RegistryKey.FROG_VARIANT),
                             Frog.Variant.class, "frogvariant")
                     .user("frog ?variants?")
                     .name("Frog Variant")


### PR DESCRIPTION
Someone posted about this in the Discord and I thought, might as well make a small fix for it.